### PR TITLE
Support installation as composer dependency.

### DIFF
--- a/bin/sw
+++ b/bin/sw
@@ -1,15 +1,19 @@
 #!/usr/bin/env php
 <?php
 error_reporting(-1);
-ini_set('display_errors', true);
-set_include_path(dirname(__DIR__));
+ini_set('display_errors', 1);
 
-if (!file_exists(dirname(__DIR__) . '/vendor/autoload.php')) {
-    echo "vendor/autoload.php not found. Please run `composer install` first\n";
-    exit(1);
+function includeIfExists($file)
+{
+    return file_exists($file) ? include $file : false;
 }
 
-$loader = require_once dirname(__DIR__) . '/vendor/autoload.php';
+if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
+    echo 'You must set up the project dependencies, run the following commands:'.PHP_EOL.
+            'curl -sS https://getcomposer.org/installer | php'.PHP_EOL.
+            'php composer.phar install'.PHP_EOL;
+    exit(1);
+}
 
 $application = new ShopwareCli\Application($loader);
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,6 @@
 {
+    "name": "shopware-ag/cli-tools",
+    "type": "application",
     "license": "MIT",
     "require": {
         "php": ">=5.3.2",
@@ -16,5 +18,10 @@
             "ShopwareCli\\": "src/"
         }
     },
-    "bin": ["bin/sw"]
+    "bin": ["bin/sw"],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
+        }
+    }
 }


### PR DESCRIPTION
This PR adds support to install the sw-cli-tools as an composer dependency for later integration to packagist.org.
## Testing

Create a new composer project:

composer.json 

```
{
    "require": {
        "shopware-ag/cli-tools": "dev-composer-support"
    },
    "repositories": [
        {
            "type": "vcs",
            "url":  "git@github.com:ShopwareAG/sw-cli-tools.git"
        }
    ]
}
```

```
# install sw-cli-tools as dependency
composer install
# sw binary should be available in vendor/bin
/vendor/bin/sw
```
