### PR TITLE
Add license information.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 shopware AG
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/box.json
+++ b/box.json
@@ -3,6 +3,7 @@
     "chmod": "0755",
     "directories": ["src"],
     "files": [
+        "LICENSE",
         "README.md",
         "config.yaml.dist",
         "vendor/autoload.php"

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "license": "MIT",
     "require": {
         "php": ">=5.3.2",
         "ext-curl": "*",


### PR DESCRIPTION
I created a license file and put license information in composer.json.

The license file was created using ://choosealicense.com/licenses/mit/.

The previous sw cli tools where licensed under MIT, see https://github.com/ShopwareAG/Shopware4-CLI-Tools. 

I also would like to omit file headers with license information to keep it simple.

If we need file headers we should keep it nice and short like the symfony framework does it for example:

```
/*
 * This file is part of sw-cli-tools.
 *
 * (c) shopware AG
 *
 * For the full copyright and license information, please view the LICENSE
 * file that was distributed with this source code.
 */
```
