### PR TITLE
Add pre-commit git hook to check CS

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ For building the release packages (sw.phar) [box](https://github.com/kherge/php-
 
 # Coding standard
 Coding standard for the project is [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
-Coding standard violations may be detected using phpcs:
+Coding standard violations may be detected using php-cs-fixer:
 
-    ./vendor/bin/phpcs --standard=PSR2 ./src ./tests
+    ./vendor/bin/php-cs-fixer fix -v --level=psr2 ./src
+    ./vendor/bin/php-cs-fixer fix -v --level=psr2 ./tests

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,11 @@
     "require-dev": {
         "ext-phar": "*",
         "phpunit/phpunit": "@stable",
-        "squizlabs/php_codesniffer": "~2"
+        "fabpot/php-cs-fixer": "^1.10"
+    },
+    "scripts": {
+        "post-install-cmd": "ln -sf ../../hooks/pre-commit .git/hooks/pre-commit",
+        "post-update-cmd": "ln -sf ../../hooks/pre-commit .git/hooks/pre-commit"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6c577d509b784d53b2147a2da36e2a63",
+    "hash": "69d4bcfdafdb8d367e1c01f6f9f5310a",
+    "content-hash": "e23ce8c17e9c9d5efa2b013194093b3c",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -86,8 +87,7 @@
                 {
                     "name": "Kevin Herrera",
                     "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io/",
-                    "role": "Developer"
+                    "homepage": "http://kevin.herrera.io"
                 }
             ],
             "description": "A library for simplifying JSON linting and validation.",
@@ -146,8 +146,7 @@
                 {
                     "name": "Kevin Herrera",
                     "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io/",
-                    "role": "Developer"
+                    "homepage": "http://kevin.herrera.io"
                 }
             ],
             "description": "A library for self-updating Phars.",
@@ -198,8 +197,7 @@
                 {
                     "name": "Kevin Herrera",
                     "email": "kevin@herrera.io",
-                    "homepage": "http://kevin.herrera.io/",
-                    "role": "Developer"
+                    "homepage": "http://kevin.herrera.io"
                 }
             ],
             "description": "A library for creating, editing, and comparing semantic versioning numbers.",
@@ -461,12 +459,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Config.git",
+                "url": "https://github.com/symfony/config.git",
                 "reference": "5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
+                "url": "https://api.github.com/repos/symfony/config/zipball/5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
                 "reference": "5ab9ff48b3cb5b40951a607f77fc1cbfd29edba8",
                 "shasum": ""
             },
@@ -511,12 +509,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
+                "url": "https://github.com/symfony/console.git",
                 "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8",
                 "shasum": ""
             },
@@ -568,12 +566,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/DependencyInjection.git",
+                "url": "https://github.com/symfony/dependency-injection.git",
                 "reference": "c0a3a97b9450d77cd8eff81c5825efb3624c255b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/DependencyInjection/zipball/c0a3a97b9450d77cd8eff81c5825efb3624c255b",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/c0a3a97b9450d77cd8eff81c5825efb3624c255b",
                 "reference": "c0a3a97b9450d77cd8eff81c5825efb3624c255b",
                 "shasum": ""
             },
@@ -628,12 +626,12 @@
             "version": "v2.7.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Filesystem.git",
+                "url": "https://github.com/symfony/filesystem.git",
                 "reference": "f079e9933799929584200b9a926f72f29e291654"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Filesystem/zipball/f079e9933799929584200b9a926f72f29e291654",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f079e9933799929584200b9a926f72f29e291654",
                 "reference": "f079e9933799929584200b9a926f72f29e291654",
                 "shasum": ""
             },
@@ -825,6 +823,60 @@
                 "instantiate"
             ],
             "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "fabpot/php-cs-fixer",
+            "version": "v1.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
+                "reference": "12dbcd1462f1e3a5a96c6c7398af26b28e092a8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/12dbcd1462f1e3a5a96c6c7398af26b28e092a8a",
+                "reference": "12dbcd1462f1e3a5a96c6c7398af26b28e092a8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.6",
+                "sebastian/diff": "~1.1",
+                "symfony/console": "~2.3",
+                "symfony/event-dispatcher": "~2.1",
+                "symfony/filesystem": "~2.1",
+                "symfony/finder": "~2.1",
+                "symfony/process": "~2.3",
+                "symfony/stopwatch": "~2.5"
+            },
+            "require-dev": {
+                "satooshi/php-coveralls": "0.7.*@dev"
+            },
+            "bin": [
+                "php-cs-fixer"
+            ],
+            "type": "application",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\CS\\": "Symfony/CS/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dariusz Rumiński",
+                    "email": "dariusz.ruminski@gmail.com"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "A tool to automatically fix PHP code style",
+            "time": "2015-10-12 20:13:46"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1675,78 +1727,160 @@
             "time": "2015-06-21 13:59:46"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.3.4",
+            "name": "symfony/event-dispatcher",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2"
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
-                "reference": "11a2545c44a5915f883e2e5ec12e14ed345e3ab2",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
+                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
                 "shasum": ""
             },
             "require": {
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.3.9"
             },
-            "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
-            ],
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.0,>=2.0.5",
+                "symfony/dependency-injection": "~2.6",
+                "symfony/expression-language": "~2.6",
+                "symfony/phpunit-bridge": "~2.7",
+                "symfony/stopwatch": "~2.3"
+            },
+            "suggest": {
+                "symfony/dependency-injection": "",
+                "symfony/http-kernel": ""
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.7-dev"
                 }
             },
             "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
-            "keywords": [
-                "phpcs",
-                "standards"
+            "description": "Symfony EventDispatcher Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-09-22 13:49:29"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v2.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "8262ab605973afbb3ef74b945daabf086f58366f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8262ab605973afbb3ef74b945daabf086f58366f",
+                "reference": "8262ab605973afbb3ef74b945daabf086f58366f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
             ],
-            "time": "2015-09-09 00:18:50"
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-09-19 19:59:23"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v2.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "08dd97b3f22ab9ee658cd16e6758f8c3c404336e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/08dd97b3f22ab9ee658cd16e6758f8c3c404336e",
+                "reference": "08dd97b3f22ab9ee658cd16e6758f8c3c404336e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "~2.7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2015-09-22 13:49:29"
         }
     ],
     "aliases": [],

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,162 @@
+#!/usr/bin/env php
+<?php
+/**
+ * .git/hooks/pre-commit
+ *
+ * This pre-commit hooks will check for PHP errors (lint), and make sure the
+ * code is PSR-2 compliant.
+ *
+ * Dependency: PHP-CS-Fixer (http://cs.sensiolabs.org/)
+ */
+
+class PreCommitChecks
+{
+    /**
+     * @var bool
+     */
+    private $error = false;
+
+    /**
+     * @return int
+     */
+    public function run()
+    {
+        $fileList = $this->getCommittedFileList();
+
+        if ($this->isRebase()) {
+            echo 'Not on branch' . PHP_EOL;
+            return (int) 0;
+        }
+
+        $this->stashTree();
+
+        echo 'Running PHP lint' . PHP_EOL;
+        if (!$this->phpLint($fileList)) {
+            echo 'There are some PHP syntax errors!' . PHP_EOL;
+        }
+
+        if ($this->isPHPCSFixerAvailable()) {
+            echo 'Checking code style' . PHP_EOL;
+            if (!$this->checkCodeStyle($fileList)) {
+                echo "Your commit does not comply with Shopware's coding standards." . PHP_EOL;
+            }
+        } else {
+            echo "PHP-CS-Fixer is NOT installed. Please run composer install --dev." . PHP_EOL;
+            $this->error = true;
+        }
+
+        if ($this->error) {
+            echo "If you are ABSOLUTELY sure your code is correct, you can use 'git commit --no-verify' to bypass this validation" . PHP_EOL;
+        }
+
+        $this->unstashTree();
+
+        exit((int) $this->error);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPHPCSFixerAvailable()
+    {
+        $output = [];
+        $return = 0;
+
+        exec('command -v '.__DIR__.'/../vendor/bin/php-cs-fixer >/dev/null 2>&1', $output, $return);
+
+        return !(bool) $return;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getCommittedFileList()
+    {
+        $output = [];
+        $return = 0;
+        exec('git rev-parse --verify HEAD 2> /dev/null', $output, $return);
+        // diff against HEAD or an empty tree object
+        $against = $return == 0 ? 'HEAD' : '4b825dc642cb6eb9a060e54bf8d69288fbee4904';
+
+        $fileList = [];
+        exec("git diff --cached --name-only --diff-filter=ACM {$against} | grep -e '\.php$'", $fileList);
+
+        return $fileList;
+    }
+
+    /**
+     * @param string[] $files
+     * @return bool
+     */
+    private function checkCodeStyle(array $files)
+    {
+        $succeed = true;
+
+        foreach ($files as $file) {
+            $output = [];
+            $return = null;
+            exec(__DIR__."/../vendor/bin/php-cs-fixer fix -v --dry-run --level=psr2 " . escapeshellarg($file), $output, $return);
+            if ($return != 0) {
+                echo "Code style error at " . $file . ":" . PHP_EOL;
+                echo implode(PHP_EOL, $output) . PHP_EOL;
+                echo "   To fix, run: ./vendor/bin/php-cs-fixer fix -v --level=psr2 " . escapeshellarg($file) . PHP_EOL;
+                $this->error = true;
+                $succeed = false;
+            }
+        }
+
+        return $succeed;
+    }
+
+    /**
+     * @param string[] $files
+     * @return bool
+     */
+    private function phpLint(array $files)
+    {
+        $succeed = true;
+
+        foreach ($files as $file) {
+            $output = [];
+            $return = 0;
+            exec("php -l " . escapeshellarg($file), $output, $return);
+            if ($return != 0) {
+                echo "PHP syntax error at " . $file . ":" . PHP_EOL;
+                echo implode(PHP_EOL, $output) . PHP_EOL;
+                $this->error = true;
+                $succeed = false;
+            }
+        }
+
+        return $succeed;
+    }
+
+    /**
+     * @return bool
+     */
+    private function isRebase()
+    {
+        $output = [];
+        exec("git symbolic-ref --short -q HEAD", $output);
+        return (empty($output));
+    }
+
+    /**
+     * Stash any changes to the working tree that are not going to be committed
+     */
+    private function stashTree()
+    {
+        exec("git stash -q --keep-index");
+    }
+
+    /**
+     * Unstash changes to the working tree that we had stashed
+     */
+    private function unstashTree()
+    {
+        exec("git stash pop -q");
+    }
+}
+
+$checks = new PreCommitChecks();
+$checks->run();

--- a/src/Extensions/Shopware/Plugin/Services/PluginProvider.php
+++ b/src/Extensions/Shopware/Plugin/Services/PluginProvider.php
@@ -102,7 +102,7 @@ class PluginProvider
         $result = array();
         foreach ($this->repositories as $repo) {
             if ($repo instanceof BaseRepository && stripos($repo->getName(), $name) !== false) {
-               $result = array_merge($result, $repo->getPlugins());
+                $result = array_merge($result, $repo->getPlugins());
             }
         }
 


### PR DESCRIPTION
It's still possible to commit invalid files using the commit option `-n` or `--no-verify`. 
`git commit -n -m"Commit some files with invalid CS.`"

I'm still undecided which tools should be used for the checks:
- php lint `php -l` 
- php-cs-fixer `php php-cs-fixer.phar fix src/ --dry-run --level=psr2 --verbose` 
- phpcs `./vendor/bin/phpcs --standard=psr2 src -n`

CS issues can be automatiically fixed using
- `$ ./vendor/bin/phpcbf --standard=psr2 src`
- `$ php-cs-fixer php php-cs-fixer.phar fix src/ --level=psr2 --verbose` 

@dnoegel What's your optionion on this topic?