### PR TITLE
Use container parameter bag instead of own config class

### DIFF
--- a/config.yaml.dist
+++ b/config.yaml.dist
@@ -1,111 +1,112 @@
-repositories:
-  ## Github API
-#  GitHub:
-#    ## General repo configuration
-#    config:
-#      ## API username
-#      username: GITHUB_USER
-#      ## API password
-#      password: GITHUB_PASSWORD
-#      ## API endpoint
-#      endpoint: https://api.github.com
-#    ## This defines the repos that are used with the GitHub repo type
-#    repositories:
-#      ## A user defined name for a repo
-#      private:
-#        ## How long should this be cached?
-#        cache: 86400
-#        ## URL which returns the branches of the repo
-#        url: orgs/MyPluginRepos/repos
-#        ## Plugins of this repo will be shown in this color within the repo listing
-#        color: red
+parameters:
+  repositories:
+    ## Github API
+  #  GitHub:
+  #    ## General repo configuration
+  #    config:
+  #      ## API username
+  #      username: GITHUB_USER
+  #      ## API password
+  #      password: GITHUB_PASSWORD
+  #      ## API endpoint
+  #      endpoint: https://api.github.com
+  #    ## This defines the repos that are used with the GitHub repo type
+  #    repositories:
+  #      ## A user defined name for a repo
+  #      private:
+  #        ## How long should this be cached?
+  #        cache: 86400
+  #        ## URL which returns the branches of the repo
+  #        url: orgs/MyPluginRepos/repos
+  #        ## Plugins of this repo will be shown in this color within the repo listing
+  #        color: red
 
 
-  ## Bitbucket API
-#  BitBucket:
-#    config:
-#      username: BITBUCKET_USER
-#      password: BITBUCKET_PASSWORD
-#      endpoint: https://bitbucket.org/api/2.0
-#    repositories:
-#      all:
-#        cache: 86400
-#        url: repositories/BITBUCKET_REPO?pagelen=100
-#        color: white
-
-
-
-  ## Stash API
-#  Stash:
-#    config:
-#      username: STASH_USER
-#      password: STASH_PASSWORD
-#      endpoint: http://you-stash-instande.tld/rest/api/1.0
-#    repositories:
-    ## You can also use your stash user space as repo. Public
-    ## repos will be shown in the plugin list
-#      stash.user:
-#        cache: 86400
-#        url: users/s.user/repos?limit=100
-#      myrepo:
-#       cache: 86400
-#       url: projects/MYREPO/repos?limit=100
-#       color: blue
-
-  ## If you want to maintain a manual collection of repositories, you can use SimpleList
-  ## Even here you can use colors and repos / collections of plugins
-  SimpleList:
-    repositories:
-      example1:
-        color: yellow
-        plugins:
-          Core_SwagJobQueue: ## Schema: MODULE_PLUGINNAME
-            ssh: git@github.com:bcremer/SwagJobQueue.git
-            http: https://github.com/bcremer/SwagJobQueue.git
-
-general:
-  # Allows you do determine how the plugin repositories should be sorted
-  # Allowed values are:
-  #   module          Sort by module and then by name
-  #   name            Sort by name
-  #   repository      Sort by repository - and then by name
-  sortBy: repository
-
-  # Do you want to use colors in your listing?
-  enableRepositoryColors: true
-
-update:
-  # Manifest url for internal updates
-  manifestUrl: https://github.com/ShopwareAG/sw-cli-tools/blob/master/manifest.json
-  checkOnStartup: false
+    ## Bitbucket API
+  #  BitBucket:
+  #    config:
+  #      username: BITBUCKET_USER
+  #      password: BITBUCKET_PASSWORD
+  #      endpoint: https://bitbucket.org/api/2.0
+  #    repositories:
+  #      all:
+  #        cache: 86400
+  #        url: repositories/BITBUCKET_REPO?pagelen=100
+  #        color: white
 
 
 
-ShopConfig:
-  host:
+    ## Stash API
+  #  Stash:
+  #    config:
+  #      username: STASH_USER
+  #      password: STASH_PASSWORD
+  #      endpoint: http://you-stash-instande.tld/rest/api/1.0
+  #    repositories:
+      ## You can also use your stash user space as repo. Public
+      ## repos will be shown in the plugin list
+  #      stash.user:
+  #        cache: 86400
+  #        url: users/s.user/repos?limit=100
+  #      myrepo:
+  #       cache: 86400
+  #       url: projects/MYREPO/repos?limit=100
+  #       color: blue
 
-DatabaseConfig:
-  host: localhost
-  user: root
-  pass: root
+    ## If you want to maintain a manual collection of repositories, you can use SimpleList
+    ## Even here you can use colors and repos / collections of plugins
+    SimpleList:
+      repositories:
+        example1:
+          color: yellow
+          plugins:
+            Core_SwagJobQueue: ## Schema: MODULE_PLUGINNAME
+              ssh: git@github.com:bcremer/SwagJobQueue.git
+              http: https://github.com/bcremer/SwagJobQueue.git
 
-## Here you can specify a list of repositories to checkout.
-# You can specify the destination path with the "destination" field
-#
-# Warning: The "core" repository is always required - it is the main
-# shopware repo to checkout. If you want to, you can replace the ssh/http
-# urls with urls to your own repository.
-ShopwareInstallRepos:
-  core:
-    destination: /
-    ssh: git@github.com:ShopwareAG/shopware-4.git
-    http: https://github.com/ShopwareAG/shopware-4.git
+  general:
+    # Allows you do determine how the plugin repositories should be sorted
+    # Allowed values are:
+    #   module          Sort by module and then by name
+    #   name            Sort by name
+    #   repository      Sort by repository - and then by name
+    sortBy: repository
 
-  ##
-  # Here you could add own plugins and other stuff you want to include in any
-  # installation you set up
-  # e.g.
-  # my-plugin:
-  #   destination: /engine/Shopware/Plugins/Local/Core/SwagMyPlugin
-  #    ssh: git@github.com:ShopwareAG/swag-my-plugin.git
-  #    http: https://github.com/ShopwareAG/swag-my-plugin.git
+    # Do you want to use colors in your listing?
+    enableRepositoryColors: true
+
+  update:
+    # Manifest url for internal updates
+    manifestUrl: https://github.com/ShopwareAG/sw-cli-tools/blob/master/manifest.json
+    checkOnStartup: false
+
+
+
+  ShopConfig:
+    host:
+
+  DatabaseConfig:
+    host: localhost
+    user: root
+    pass: root
+
+  ## Here you can specify a list of repositories to checkout.
+  # You can specify the destination path with the "destination" field
+  #
+  # Warning: The "core" repository is always required - it is the main
+  # shopware repo to checkout. If you want to, you can replace the ssh/http
+  # urls with urls to your own repository.
+  ShopwareInstallRepos:
+    core:
+      destination: /
+      ssh: git@github.com:ShopwareAG/shopware-4.git
+      http: https://github.com/ShopwareAG/shopware-4.git
+
+    ##
+    # Here you could add own plugins and other stuff you want to include in any
+    # installation you set up
+    # e.g.
+    # my-plugin:
+    #   destination: /engine/Shopware/Plugins/Local/Core/SwagMyPlugin
+    #    ssh: git@github.com:ShopwareAG/swag-my-plugin.git
+    #    http: https://github.com/ShopwareAG/swag-my-plugin.git

--- a/src/Application.php
+++ b/src/Application.php
@@ -50,13 +50,15 @@ class Application extends \Symfony\Component\Console\Application
         $container = $this->createContainer($input, $output);
         $this->checkDirectories();
 
+        $container->get('config_loader')->loadConfig($container);
+
         $noExtensions = $input->hasParameterOption('--no-extensions');
         $this->loadExtensions($noExtensions);
 
         // Compile the container after the plugins did their container extensions
         $container->compile();
-
         $this->addCommands($container->get('command_manager')->getCommands());
+
 
         $container->get('plugin_provider')->setRepositories($container->get('repository_manager')->getRepositories());
 

--- a/src/Application/DependencyInjection.php
+++ b/src/Application/DependencyInjection.php
@@ -21,6 +21,10 @@ class DependencyInjection
         $container->setDefinition('output_interface', new Definition('Symfony\Component\Console\Input\InputInterface'))->setSynthetic(true);
         $container->setDefinition('question_helper', new Definition('Symfony\Component\Console\Helper\QuestionHelper'))->setSynthetic(true);
 
+        $container->register('config_loader', 'ShopwareCli\Services\ConfigLoader')
+            ->setPublic(false)
+            ->addArgument(new Reference('path_provider'));
+
         $container->register('io_service', 'ShopwareCli\Services\IoService')
             ->addArgument(new Reference('input_interface'))
             ->addArgument(new Reference('output_interface'))
@@ -58,7 +62,7 @@ class DependencyInjection
             ->addArgument(new Reference('service_container'));
 
         $container->register('config', 'ShopwareCli\Config')
-            ->addArgument(new Reference('path_provider'));
+            ->addArgument(new Reference('service_container'));
 
         $container->register('extension_manager', 'ShopwareCli\Application\ExtensionManager')
             ->addArgument(new Reference('autoloader'));
@@ -67,6 +71,8 @@ class DependencyInjection
             ->addArgument(new Reference('extension_manager'))
             ->addArgument(new Reference('service_container'));
 
+
         return $container;
     }
+
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,6 +3,7 @@
 namespace ShopwareCli;
 
 use ShopwareCli\Services\PathProvider\PathProvider;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -10,100 +11,21 @@ use Symfony\Component\Yaml\Yaml;
  *
  * Class Config
  * @package ShopwareCli
+ * @deprecated Use the container for config handling instead
  */
 class Config implements \ArrayAccess
 {
     /**
-     * @var array
+     * @var \Symfony\Component\DependencyInjection\Container
      */
-    protected $configArray;
-
-    /**
-     * @var PathProvider
-     */
-    private $pathProvider;
+    private $container;
 
     /**
      * @param PathProvider $pathProvider
      */
-    public function __construct(PathProvider $pathProvider)
+    public function __construct(Container $container)
     {
-        $this->pathProvider = $pathProvider;
-
-        $config = $this->getMergedConfigs($this->collectConfigFiles());
-        $this->configArray = Yaml::parse($config, true);
-    }
-
-    /**
-     * Iterate the extension directories and return config.yaml files
-     *
-     * @return string[]
-     */
-    private function collectConfigFiles()
-    {
-        $files = array();
-
-        // Load user file first. Its config values cannot be overwritten
-        $userConfig = $this->pathProvider->getConfigPath() . '/config.yaml';
-        if (file_exists($userConfig)) {
-            $files[] = $userConfig;
-        }
-
-        // load config.yaml files from extensions
-        $vendorIterator = new \DirectoryIterator($this->pathProvider->getExtensionPath());
-        /** @var $vendorFileInfo \DirectoryIterator */
-        foreach ($vendorIterator as $vendorFileInfo) {
-            if (!$this->isValidDir($vendorFileInfo)) {
-                continue;
-            }
-            $extensionIterator = new \DirectoryIterator($vendorFileInfo->getPathname());
-
-            /** @var $extensionFileInfo \DirectoryIterator */
-            foreach ($extensionIterator as $extensionFileInfo) {
-                if (!$this->isValidDir($extensionFileInfo)) {
-                    continue;
-                }
-                $file = $extensionFileInfo->getPathname() . '/config.yaml';
-
-                if (file_exists($file)) {
-                    $files[] = $file;
-                }
-            }
-        }
-
-        // Load config.yaml.dist as latest - this way the fallback config options are defined
-        $files[] = $this->pathProvider->getCliToolPath() . '/config.yaml.dist';
-        return $files;
-    }
-
-    /**
-     * @param \DirectoryIterator $fileInfo
-     *
-     * @return bool
-     */
-    private function isValidDir(\DirectoryIterator $fileInfo)
-    {
-        return $fileInfo->isDir() && !$fileInfo->isDot() && stripos(
-            $fileInfo->getBasename(),
-            '.'
-        ) !== 0; // skip dot directories e.g. .git
-    }
-
-    /**
-     * Merge all given config.yaml files
-     *
-     * @param  string[] $paths
-     * @return string
-     */
-    private function getMergedConfigs($paths)
-    {
-        $content = array();
-
-        foreach ($paths as $path) {
-            $content[] = file_get_contents($path);
-        }
-
-        return implode("\n", $content);
+        $this->container = $container;
     }
 
     /**
@@ -111,7 +33,7 @@ class Config implements \ArrayAccess
      */
     public function getRepositories()
     {
-        return $this->configArray['repositories'];
+        return $this->container->getParameter('repositories');
     }
 
     /**
@@ -121,7 +43,8 @@ class Config implements \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return isset($this->configArray[$offset]);
+        $var = $this->container->getParameter($offset);
+        return isset($var);
     }
 
     /**
@@ -131,7 +54,7 @@ class Config implements \ArrayAccess
      */
     public function offsetGet($offset)
     {
-        return $this->configArray[$offset];
+        return $this->container->getParameter($offset);
     }
 
     /**
@@ -140,14 +63,15 @@ class Config implements \ArrayAccess
      */
     public function offsetSet($offset, $value)
     {
-        $this->configArray[$offset] = $value;
+        $this->container->setParameter($offset, $value);
     }
 
     /**
      * @param mixed $offset
+     * @throws \RuntimeException
      */
     public function offsetUnset($offset)
     {
-        unset($this->configArray[$offset]);
+        throw new \RuntimeException("Not implemented");
     }
 }

--- a/src/Services/ConfigLoader.php
+++ b/src/Services/ConfigLoader.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace ShopwareCli\Services;
+
+use ShopwareCli\Services\PathProvider\PathProvider;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+/**
+ * Will discover all config files and set them into the container
+ *
+ * Class ConfigLoader
+ * @package ShopwareCli\Services
+ */
+class ConfigLoader
+{
+
+    /**
+     * @var PathProvider
+     */
+    private $pathProvider;
+
+    public function __construct(PathProvider $pathProvider)
+    {
+
+        $this->pathProvider = $pathProvider;
+    }
+
+    /**
+     * Will discover all config files and set the config options to the parameter bag
+     *
+     * @param $container
+     */
+    public function loadConfig($container)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator());
+        foreach($this->collectConfigFiles() as $file) {
+            $loader->load($file);
+        }
+    }
+
+    /**
+     * Iterate the extension directories and return config.yaml files
+     *
+     * @return string[]
+     */
+    private function collectConfigFiles()
+    {
+        $files = array();
+
+        // Load user file first. Its config values cannot be overwritten
+        $userConfig = $this->pathProvider->getConfigPath() . '/config.yaml';
+        if (file_exists($userConfig)) {
+            $files[] = $userConfig;
+        }
+
+        // load config.yaml files from extensions
+        $vendorIterator = new \DirectoryIterator($this->pathProvider->getExtensionPath());
+        /** @var $vendorFileInfo \DirectoryIterator */
+        foreach ($vendorIterator as $vendorFileInfo) {
+            if (!$this->isValidDir($vendorFileInfo)) {
+                continue;
+            }
+            $extensionIterator = new \DirectoryIterator($vendorFileInfo->getPathname());
+
+            /** @var $extensionFileInfo \DirectoryIterator */
+            foreach ($extensionIterator as $extensionFileInfo) {
+                if (!$this->isValidDir($extensionFileInfo)) {
+                    continue;
+                }
+                $file = $extensionFileInfo->getPathname() . '/config.yaml';
+
+                if (file_exists($file)) {
+                    $files[] = $file;
+                }
+            }
+        }
+
+        // Load config.yaml.dist as latest - this way the fallback config options are defined
+        $files[] = $this->pathProvider->getCliToolPath() . '/config.yaml.dist';
+        return $files;
+    }
+
+    /**
+     * @param \DirectoryIterator $fileInfo
+     *
+     * @return bool
+     */
+    private function isValidDir(\DirectoryIterator $fileInfo)
+    {
+        return $fileInfo->isDir() && !$fileInfo->isDot() && stripos(
+            $fileInfo->getBasename(),
+            '.'
+        ) !== 0; // skip dot directories e.g. .git
+    }
+}


### PR DESCRIPTION
Make use of the container parameter bag instead of having an own config object.

For compatibility reasons the old config object is currently still maintained and just accesses the parameter bag.

This will break existing config.yaml files because they  are missing the 'parameters' identation level