### PR TITLE
added option to sw:install:vcs for excluding demodata

### DIFF
--- a/src/Extensions/Shopware/Install/Command/ShopwareInstallVcsCommand.php
+++ b/src/Extensions/Shopware/Install/Command/ShopwareInstallVcsCommand.php
@@ -47,6 +47,12 @@ class ShopwareInstallVcsCommand extends BaseCommand
                 InputOption::VALUE_OPTIONAL,
                 'GIT repos username. If given, checkout will be done using HTTP'
             )
+            ->addOption(
+                'noDemoData',
+                null,
+                InputOption::VALUE_NONE,
+                'If set, the demo data will not be installed'
+            )
             ->setHelp(
 <<<EOF
 The <info>%command.name%</info> sets up shopware
@@ -68,7 +74,8 @@ EOF
             trim($input->getOption('installDir'), '/'),
             $input->getOption('basePath'),
             $input->getOption('databaseName'),
-            $input->getOption('user')
+            $input->getOption('user'),
+            $input->getOption('noDemoData')
         );
     }
 

--- a/src/Extensions/Shopware/Install/Services/Install/Vcs.php
+++ b/src/Extensions/Shopware/Install/Services/Install/Vcs.php
@@ -72,16 +72,20 @@ class Vcs
      * @param string $installDir
      * @param $basePath
      * @param $database
-     * @param null   $httpUser
+     * @param null $httpUser
+     * @param bool $noDemoData
      */
-    public function installShopware($branch, $installDir, $basePath, $database, $httpUser = null)
+    public function installShopware($branch, $installDir, $basePath, $database, $httpUser = null, $noDemoData = false)
     {
         $this->checkoutRepos($branch, $installDir, $httpUser);
         $this->generateVcsMapping($installDir);
         $this->writeBuildProperties($installDir, $basePath, $database);
         $this->setupDatabase($installDir, $database);
-        $this->demoData->setup($installDir);
         $this->demoData->runLicenseImport($installDir);
+
+        if (!$noDemoData) {
+            $this->demoData->setup($installDir);
+        }
 
         $this->ioService->writeln("<info>Running post release scripts</info>");
         $this->postInstall->fixPermissions($installDir);


### PR DESCRIPTION
this commit adds a new option to **install:vcs**. now it is possible to disable the installation of the demo data