### PR TITLE
phpunit.xml.dist.tpl: fix path to TestHelper.php

### DIFF
--- a/src/Extensions/Shopware/PluginCreator/template/phpunit.xml.dist.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/phpunit.xml.dist.tpl
@@ -1,5 +1,5 @@
 <?= '<?xml version="1.0" encoding="UTF-8"?>'; ?>
-<phpunit bootstrap="./../../../../../../../tests/TestHelper.php">
+<phpunit bootstrap="../../../../../../tests/Shopware/TestHelper.php">
 <testsuite name="<?= $configuration->name; ?> Test Suite">
     <directory>tests</directory>
 </testsuite>


### PR DESCRIPTION
TestHelper.php is located inside $shopware_root/tests/Shopware/TestHelper.php,
not $shopware_root/engine/tests/TestHelper.php, so correct path here.