### PR TITLE
normalize install suggestion

### DIFF
--- a/src/Extensions/Shopware/Install/Command/ShopwareInstallVcsCommand.php
+++ b/src/Extensions/Shopware/Install/Command/ShopwareInstallVcsCommand.php
@@ -9,7 +9,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ShopwareInstallVcsCommand extends BaseCommand
 {
-    const MAIN_BRANCH = '5.0';
+    const MAIN_BRANCH = '5.1';
 
     /**
      * {@inheritdoc}
@@ -118,7 +118,7 @@ EOF
             return 'sw' . $result['number'];
         }
 
-        return $branch;
+        return str_replace('.', '', $branch);
     }
 
     /**


### PR DESCRIPTION
Normalize the suggested directory / database name / basepath:
```
daniel@dn:~/www$ sw install:vcs -u
Please provide the branch you want to install <5.1>: 4.0.8
Please provide the install directory <408>: 
Please provide the database name you want to use <408>: 
Please provide the basepath you want to use <408>: 
```

Seems more convenient to me - but I am open for objections :)