### PR TITLE
SW 5.2.x compatibility issue

### DIFF
--- a/src/Extensions/Shopware/PluginCreator/template/Bootstrap.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/Bootstrap.tpl
@@ -73,7 +73,7 @@ class Shopware_Plugins_<?= $configuration->namespace; ?>_<?= $configuration->nam
             'class' => 'sprite-application-block',
             'action' => 'Index',
             'active' => 1,
-            'parent' => $this->Menu()->findOneBy('label', 'Marketing')
+            'parent' => $this->Menu()->findOneBy(array('label' => 'Marketing'))
         ));
 <?php } ?>
 


### PR DESCRIPTION
$this->Menu()->findOneBy('label', 'Marketing') throws an error.
Since SW 5.2.x $this->Menu()->findOneBy requires an key-value based array for the param $criteria.