### PR TITLE
Fixed and refactor template current/legacy xml files header

### DIFF
--- a/src/Extensions/Shopware/PluginCreator/template/current/Resources/config.xml.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/Resources/config.xml.tpl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?= '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL; ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../../engine/Shopware/Components/Plugin/schema/config.xsd">
 

--- a/src/Extensions/Shopware/PluginCreator/template/current/Resources/menu.xml.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/Resources/menu.xml.tpl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?= '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL; ?>
 <menu xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/shopware/shopware/5.2/engine/Shopware/Components/Plugin/schema/menu.xsd">
     <entries>
         <entry>

--- a/src/Extensions/Shopware/PluginCreator/template/current/Resources/services.xml.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/Resources/services.xml.tpl
@@ -1,5 +1,4 @@
-<?xml version="1.0" ?>
-
+<?= '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL; ?>
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">

--- a/src/Extensions/Shopware/PluginCreator/template/current/phpunit.xml.dist.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/phpunit.xml.dist.tpl
@@ -1,4 +1,4 @@
-<?= '<?xml version="1.0" encoding="UTF-8"?>'; ?>
+<?= '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL; ?>
 <phpunit bootstrap="../../../tests/Functional/bootstrap.php">
 <testsuite name="<?= $configuration->name; ?> Test Suite">
     <directory>tests</directory>

--- a/src/Extensions/Shopware/PluginCreator/template/current/plugin.xml.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/plugin.xml.tpl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?= '<?xml version="1.0" encoding="utf-8"?>'.PHP_EOL; ?>
 <plugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="../../../engine/Shopware/Components/Plugin/schema/plugin.xsd">
     <label lang="de"><?= $configuration->name; ?></label>

--- a/src/Extensions/Shopware/PluginCreator/template/legacy/phpunit.xml.dist.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/legacy/phpunit.xml.dist.tpl
@@ -1,4 +1,4 @@
-<?= '<?xml version="1.0" encoding="UTF-8"?>'; ?>
+<?= '<?xml version="1.0" encoding="UTF-8"?>'.PHP_EOL; ?>
 <?php if ($configuration->isLegacyPlugin) { ?>
 <phpunit bootstrap="../../../../../../tests/Shopware/TestHelper.php">
 <?php } else { ?>


### PR DESCRIPTION
php settings short_open_tag = on
then following parser exception will be thrown:
> Parse error: syntax error, unexpected '=' in phar:///scripts/sw.phar/src/Extensions/Shopware/PluginCreator/template/current/Resources/services.xml.tpl on line 1