### PR TITLE
Update ApiSubscriber.tpl

### DIFF
--- a/src/Extensions/Shopware/PluginCreator/template/current/Subscriber/ApiSubscriber.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/Subscriber/ApiSubscriber.tpl
@@ -4,7 +4,7 @@
 namespace  <?= $configuration->name; ?>\Subscriber;
 
 use Enlight\Event\SubscriberInterface;
-use Shopware\Recovery\Common\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ApiSubscriber implements SubscriberInterface
 {


### PR DESCRIPTION
fixed bug:
[06-Oct-2017 17:09:22 Europe/Berlin] PHP Fatal error:  Uncaught TypeError: Argument 1 passed to VcuMallCustom\Subscriber\ApiSubscriber::__construct() must be an instance of Shopware\Recovery\Common\DependencyInjection\ContainerInterface, instance of ShopwareProduction602a9ba0973c35efc40cfde7016f5e701ae3ad61ProjectContainer given, called in /Users/hoist/sites/shopware/var/cache/production____REVISION___/proxies/ShopwareProduction602a9ba0973c35efc40cfde7016f5e701ae3ad61ProjectContainer.php on line 2879 and defined in /Users/hoist/sites/shopware/custom/plugins/VcuMallCustom/Subscriber/ApiSubscriber.php:18
Stack trace:
#0 /Users/hoist/sites/shopware/var/cache/production____REVISION___/proxies/ShopwareProduction602a9ba0973c35efc40cfde7016f5e701ae3ad61ProjectContainer.php(2879): VcuMallCustom\Subscriber\ApiSubscriber->__construct(Object(ShopwareProduction602a9ba0973c35efc40cfde7016f5e701ae3ad61ProjectContainer))
#1 /Users/hoist/sites/shopware/vendor/symfony/dependency-injection/Container.php(304): ShopwareProduction602a9ba0973c35efc40cfde7016f5e701ae3ad61ProjectContain in /Users/hoist/sites/shopware/custom/plugins/VcuMallCustom/Subscriber/ApiSubscriber.php on line 18
