### PR TITLE
Update Backend.tpl

### DIFF
--- a/src/Extensions/Shopware/PluginCreator/template/current/Controllers/Backend.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/Controllers/Backend.tpl
@@ -7,7 +7,7 @@
  */
 class Shopware_Controllers_Backend_<?= $configuration->name; ?> extends Shopware_Controllers_Backend_Application
 {
-    protected $model = '<?= $configuration->backendModel; ?>';
+    protected $model = '\<?= $configuration->name; ?>\Models\<?= $configuration->backendModel; ?>';
     protected $alias = '<?= $names->under_score_model; ?>';
 <?php } else { ?>
 class Shopware_Controllers_Backend_<?= $configuration->name; ?> extends Shopware_Controllers_Backend_ExtJs


### PR DESCRIPTION
Fix a namespace bug: 

[06-Oct-2017 17:22:53 Europe/Berlin] PHP Fatal error:  Uncaught Doctrine\Common\Persistence\Mapping\MappingException: Class 'Book' does not exist in /Users/hoist/sites/shopware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/MappingException.php:96
Stack trace:
#0 /Users/hoist/sites/shopware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/RuntimeReflectionService.php(41): Doctrine\Common\Persistence\Mapping\MappingException::nonExistingClass('Book')
#1 /Users/hoist/sites/shopware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php(281): Doctrine\Common\Persistence\Mapping\RuntimeReflectionService->getParentClasses('Book')
#2 /Users/hoist/sites/shopware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/AbstractClassMetadataFactory.php(311): Doctrine\Common\Persistence\Mapping\AbstractClassMetadataFactory->getParentClasses('Book')
#3 /Users/hoist/sites/shopware/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php(78): Doctrine\Common\Persistence\Mapping\AbstractC in /Users/hoist/sites/shopware/vendor/doctrine/common/lib/Doctrine/Common/Persistence/Mapping/MappingException.php on line 96