### PR TITLE
Fix ".rovider" to ".provider".

### DIFF
--- a/src/Extensions/Shopware/PluginCreator/template/current/Resources/services.xml.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/Resources/services.xml.tpl
@@ -59,7 +59,7 @@
             <tag name="shopware_elastic_search.data_indexer" />
             <argument id="dbal_connection" type="service"/>
             <argument id="shopware_elastic_search.client" type="service"/>
-            <argument id="<?= $names->under_score_js ?>.search.rovider" type="service"/>
+            <argument id="<?= $names->under_score_js ?>.search.provider" type="service"/>
         </service>
 
         <service id="<?= $names->under_score_js ?>.mapping.mapping" class="<?= $configuration->name; ?>\Components\ESIndexingBundle\Mapping">


### PR DESCRIPTION
It causes:

PHP Fatal error:  Uncaught Symfony\\Component\\DependencyInjection\\Exception\\ServiceNotFoundException: The service "module_name.data_indexer.data_indexer" has a dependency on a non-existent service "module_name.search.rovider". in /vendor/symfony/dependency-injection/Compiler/CheckExceptionOnInvalidReferenceBehaviorPass.php:31