### PR TITLE
Fixed getBaseQuery select to call the correct absolute path (not relative)

### DIFF
--- a/src/Extensions/Shopware/PluginCreator/template/current/Components/Api/Resource/Resource.tpl
+++ b/src/Extensions/Shopware/PluginCreator/template/current/Components/Api/Resource/Resource.tpl
@@ -216,7 +216,7 @@ class <?= $names->camelCaseModel; ?> extends Resource
     {
         $builder = $this->getManager()->createQueryBuilder();
         $builder->select(array('<?= $names->backendModelAlias; ?>'))
-            ->from('<?= $configuration->backendModel; ?>', '<?= $names->backendModelAlias; ?>');
+            ->from('<?= $configuration->name; ?>\Models\<?= $configuration->backendModel; ?>', '<?= $names->backendModelAlias; ?>');
 
         return $builder;
     }


### PR DESCRIPTION
As per my understanding this needs to be an absolute path in this case to make it callable.