### PR TITLE
NTR - Skip swag prefixed dependencies

### DIFF
--- a/src/Extensions/Shopware/Plugin/Services/DependencyManager.php
+++ b/src/Extensions/Shopware/Plugin/Services/DependencyManager.php
@@ -58,11 +58,11 @@ class DependencyManager
 
         $shopwareDependencies = [];
         foreach ($composerJson['require'] as $dependencyName => $version) {
-            if (\strpos($dependencyName, 'shopware/') !== 0) {
-                continue;
+            if (\strpos($dependencyName, 'shopware/') === 0
+                || \strpos($dependencyName, 'swag/') === 0
+            ) {
+                $shopwareDependencies[$dependencyName] = $version;
             }
-
-            $shopwareDependencies[$dependencyName] = $version;
         }
 
         // Only Shopware dependencies skip


### PR DESCRIPTION
This will skip composer install for `swag/` prefixed dependencies as those are not resolvable by packagist.