### PR TITLE
NTR - add enterprise to sw6 plugin namespace

### DIFF
--- a/src/Extensions/Shopware/Plugin/Services/PluginFactory.php
+++ b/src/Extensions/Shopware/Plugin/Services/PluginFactory.php
@@ -15,6 +15,11 @@ use Shopware\Plugin\Struct\Plugin;
  */
 class PluginFactory
 {
+    public const SW6_PLUGIN_PATHS = [
+        'shopware/6/services',
+        'shopware/6/enterprise',
+    ];
+
     /**
      * Input is a name like Backend_SwagBusinessEssentials
      *
@@ -33,7 +38,10 @@ class PluginFactory
         $plugin->cloneUrlHttp = $httpUrl;
         $plugin->repository = $repoName;
         $plugin->repoType = $repoType;
-        $plugin->isShopware6 = (bool) \strpos($sshUrl, 'shopware/6/services'); // could not be position 0, so this is safe
+
+        $preg = \implode('|', self::SW6_PLUGIN_PATHS);
+        $preg = '/' . \str_replace('/', '\/', $preg) . '/';
+        $plugin->isShopware6 = (bool) \preg_match($preg, $sshUrl);
 
         return $plugin;
     }

--- a/tests/Unit/Extensions/Shopware/Plugin/Services/PluginFactoryTest.php
+++ b/tests/Unit/Extensions/Shopware/Plugin/Services/PluginFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+declare(strict_types=1);
+/**
+ * (c) shopware AG <info@shopware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\TestCase;
+use Shopware\Plugin\Services\PluginFactory;
+
+class PluginFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider sw6PluginDataProvider
+     */
+    public function testGetPluginIsSw6Plugin(string $name, string $sshUrl, string $httpUrl, string $repoName, ?string $repoType = null): void
+    {
+        $plugin = PluginFactory::getPlugin($name, $sshUrl, $httpUrl, $repoName, $repoType);
+
+        static::assertTrue($plugin->isShopware6);
+    }
+
+    /**
+     * @dataProvider notSw6PluginDataProvider
+     */
+    public function testGetPluginIsNotSw6Plugin(string $name, string $sshUrl, string $httpUrl, string $repoName, ?string $repoType = null): void
+    {
+        $plugin = PluginFactory::getPlugin($name, $sshUrl, $httpUrl, $repoName, $repoType);
+
+        static::assertFalse($plugin->isShopware6);
+    }
+
+    public function sw6PluginDataProvider(): Generator
+    {
+        foreach (PluginFactory::SW6_PLUGIN_PATHS as $path) {
+            yield 'Plugin is SW6 - ' . $path => [
+                'name' => 'frontend_myPluginName',
+                'sshUrl' => 'git@foo.bar.com:' . $path . '/myPlugin.git',
+                'httpUrl' => 'https://mygitlabserver.com/shopware/6/enterprise/myPlugin.git',
+                'repoName' => 'myPlugin',
+                'repoType' => null,
+            ];
+        }
+    }
+
+    public function notSw6PluginDataProvider(): Generator
+    {
+        yield 'Plugin is not SW6 - custom namespace' => [
+            'name' => 'frontend_myPluginName',
+            'sshUrl' => 'git@foo.bar.com:my/custom/namespace/myPlugin.git',
+            'httpUrl' => 'https://mygitlabserver.com/my/custom/namespace/myPlugin.git',
+            'repoName' => 'myPlugin',
+            'repoType' => null,
+        ];
+    }
+}


### PR DESCRIPTION
In order to also mark enterprise plugins as sw6 plugins, we added the enterprise namespace.

