### PR TITLE
Fixed shopware dependencies removing order, for command plugin:zip:vcs

### DIFF
--- a/src/Extensions/Shopware/Plugin/Services/DependencyManager.php
+++ b/src/Extensions/Shopware/Plugin/Services/DependencyManager.php
@@ -71,7 +71,7 @@ class DependencyManager
         }
 
         // Temporary remove shopware dependencies
-        foreach (\array_keys($shopwareDependencies) as $dependencyName) {
+        foreach ($this->getTheRightRemovingOrder(\array_keys($shopwareDependencies)) as $dependencyName) {
             $this->processExecutor->execute(\sprintf('composer remove %s --update-no-dev', $dependencyName), $pathToPlugin);
         }
 
@@ -81,5 +81,21 @@ class DependencyManager
         foreach ($shopwareDependencies as $dependencyName => $version) {
             $this->processExecutor->execute(\sprintf('composer require %s:"%s" --no-update', $dependencyName, $version), $pathToPlugin);
         }
+    }
+
+    private function getTheRightRemovingOrder(array $dependencies): array
+    {
+        usort($dependencies, function (string $a, string $b): int {
+            switch ('shopware/core') {
+                case $a:
+                    return 1;
+                case $b:
+                    return -1;
+                default:
+                    return 0;
+            }
+        });
+
+        return $dependencies;
     }
 }

--- a/tests/Unit/Extensions/Shopware/Plugin/Services/DependencyManagerTest.php
+++ b/tests/Unit/Extensions/Shopware/Plugin/Services/DependencyManagerTest.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+/**
+ * (c) shopware AG <info@shopware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Shopware\Plugin\Struct\Plugin;
+use ShopwareCli\Extensions\Shopware\Plugin\Services\DependencyManager;
+use ShopwareCli\Services\ProcessExecutor;
+
+class DependencyManagerTest extends TestCase
+{
+    /**
+     * @var ProcessExecutor&MockObject
+     */
+    private $processExecutor;
+
+    private $dependencyManager;
+
+    public function setUp(): void
+    {
+        $this->processExecutor = $this->createMock(ProcessExecutor::class);
+        $this->dependencyManager = new DependencyManager($this->processExecutor);
+    }
+
+    public function testManageDependenciesWithExternalDependenciesWillRemuveShopwareDependenciesInRightOrder(): void
+    {
+        $plugin = new Plugin();
+        $plugin->isShopware6 = true;
+        $callNumber = 0;
+
+        $this->processExecutor
+            ->method('execute')
+            ->with(static::callback(function ($command) use (&$callNumber) {
+                if ($callNumber == 2) {
+                    self::assertEquals('composer remove shopware/core --update-no-dev', $command, 'Removing shopware/core should be the last command in removing the packages commands list');
+                }
+                ++$callNumber;
+
+                return true;
+            }));
+        $this->dependencyManager->manageDependencies($plugin, __DIR__ . '/../../../../_fixtures/DependencyManager/RemoveShopwareDependencyOrder');
+    }
+}

--- a/tests/Unit/_fixtures/DependencyManager/RemoveShopwareDependencyOrder/composer.json
+++ b/tests/Unit/_fixtures/DependencyManager/RemoveShopwareDependencyOrder/composer.json
@@ -1,0 +1,16 @@
+{
+  "name": "shopware/test",
+  "description": "The Shopware Test",
+  "type": "shopware-platform-plugin",
+  "license": "proprietary",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "require": {
+    "php": "^8.1",
+    "shopware/core": "~6.5.0",
+    "shopware/storefront": "~6.5.0",
+    "shopware/administration": "~6.5.0",
+    "nikic/fast-route": "^1.0",
+    "phpoffice/phpspreadsheet": "^1.14"
+  }
+}


### PR DESCRIPTION
1. Why is this change necessary?

Currently, DependencyManager removing shopware packages in that order as the met in composer.json. That is why sometimes depending packages could be removed before the main one. That leads to the composer error in (`plugin:zip:vcs`, `plugin:zip:dir`).

3. What does this change do, exactly?

Added private method  `DependencyManager::getTheRightRemovingOrder()` that provided the correct order of removing shopware packages. Currently, it means that package shopware/core would be removed last. 
